### PR TITLE
Update GitHub Actions and macOS platform implementation.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/tmui/src/platform/platform_macos.rs
+++ b/tmui/src/platform/platform_macos.rs
@@ -10,7 +10,7 @@ use cocoa::{
         NSApp, NSApplication, NSApplicationActivationPolicy::NSApplicationActivationPolicyRegular,
         NSImage, NSImageView, NSView, NSWindow,
     },
-    base::{id, nil, NO},
+    base::{id, nil},
     foundation::{NSAutoreleasePool, NSSize},
 };
 use core_graphics::{
@@ -214,7 +214,7 @@ impl<T: 'static + Copy + Sync + Send, M: 'static + Copy + Sync + Send> PlatformC
                 &self.color_space,
                 kCGImageAlphaLast,
                 &data_provider,
-                NO,
+                false,
                 kCGRenderingIntentDefault,
             );
             let cg_img_ref = cg_image.as_ref();


### PR DESCRIPTION
- Update `.github/workflows/rust.yml` to include macOS in the matrix of operating systems for the "build" job.
- In `tmui/src/platform/platform_macos.rs`, change the use of `NO` to `false` to fix a deprecated argument.