### PR TITLE
layout: Debug leaf node size calculation

### DIFF
--- a/tmui/src/layout.rs
+++ b/tmui/src/layout.rs
@@ -141,6 +141,7 @@ impl SizeCalculation for dyn WidgetImpl {
     }
 
     fn calc_leaf_size(&mut self, window_size: Size, parent_size: Size) {
+        debug!("Calc leaf node {} size, parent_size: {:?}", self.name(), parent_size);
         let size = self.size();
         let mut resized = false;
 


### PR DESCRIPTION
The commit adds debug logging when calculating the size of a leaf node in the layout module. This logging helps to track the parent size during the calculation.