### PR TITLE
update: Adjust ScrollArea container layout to improve display.

### DIFF
--- a/examples/scrolled/scroll_window.rs
+++ b/examples/scrolled/scroll_window.rs
@@ -22,8 +22,8 @@ impl ObjectImpl for ScrollWindow {
         label.set_background(Color::CYAN);
         label.set_halign(Align::Center);
         label.set_valign(Align::Center);
-        label.width_request(200);
-        label.height_request(40);
+        // label.width_request(200);
+        // label.height_request(40);
         label.set_content_halign(Align::End);
         label.set_content_valign(Align::End);
         label.set_size(30);


### PR DESCRIPTION
- Commented out the width and height request for the label in ScrollWindow to allow it to adjust automatically.
- Added a new trait ScrollAreaExt with methods to get and set the area, scroll bar, and to get an area casted as a specific type.
- Implemented ScrollAreaExt for ScrollArea.
- Modified the set_area method in ScrollArea to adjust the layout of the area after setting it.
- Implemented type_register method to register ScrollArea with the type registry.
- Added a new method adjust_area_layout in ScrollArea to adjust the layout of the area.
- Implemented StaticContainerScaleCalculate for ScrollArea to calculate the container hscale value.

Note: The code changes aim to improve the display of ScrollWindow label and ScrollArea container.