### PR TITLE
layout: Remove debug logging in calc_leaf_size() function

### DIFF
--- a/tmui/src/layout.rs
+++ b/tmui/src/layout.rs
@@ -141,7 +141,6 @@ impl SizeCalculation for dyn WidgetImpl {
     }
 
     fn calc_leaf_size(&mut self, window_size: Size, parent_size: Size) {
-        debug!("Calc leaf node {} size, parent_size: {:?}", self.name(), parent_size);
         let size = self.size();
         let mut resized = false;
 
@@ -255,6 +254,11 @@ impl LayoutManager {
         parent_size: Size,
         widget: &mut dyn WidgetImpl,
     ) -> Size {
+        debug!(
+            "Widget {} size probe, parent_size: {:?}",
+            widget.name(),
+            parent_size
+        );
         let raw_child = widget.get_raw_child();
         let widget_ptr = widget.as_ptr_mut();
         let composition = widget.composition();

--- a/tmui/src/widget.rs
+++ b/tmui/src/widget.rs
@@ -267,6 +267,7 @@ impl<T: WidgetImpl + WidgetExt> ElementImpl for T {
         }
 
         let mut painter = Painter::new(cr.canvas(), self);
+        painter.set_font(self.font().to_skia_font());
 
         let contents_rect = self.contents_rect(Some(Coordinate::Widget));
         if contents_rect.width() <= 0 || contents_rect.height() <= 0 {


### PR DESCRIPTION
The debug log message in the calc_leaf_size() function that prints the parent size and leaf node name has been removed.