### PR TITLE
Refactored `visible` method to take `self` instead of `&mut self` in …

### DIFF
--- a/macros/src/extend_widget.rs
+++ b/macros/src/extend_widget.rs
@@ -269,7 +269,7 @@ pub(crate) fn gen_widget_trait_impl_clause(
             }
 
             #[inline]
-            fn visible(&mut self) -> bool {
+            fn visible(&self) -> bool {
                 self.#(#widget_path).*.visible()
             }
 

--- a/tmui/src/widget.rs
+++ b/tmui/src/widget.rs
@@ -373,7 +373,7 @@ pub trait WidgetExt {
     /// Return true if widget is visble, otherwise, false is returned.
     ///
     /// Go to[`Function defination`](WidgetExt::visible) (Defined in [`WidgetExt`])
-    fn visible(&mut self) -> bool;
+    fn visible(&self) -> bool;
 
     /// Setter of property `focus`.
     ///
@@ -886,7 +886,7 @@ impl WidgetExt for Widget {
     }
 
     #[inline]
-    fn visible(&mut self) -> bool {
+    fn visible(&self) -> bool {
         self.get_property("visible").unwrap().get::<bool>()
     }
 


### PR DESCRIPTION
…`extend_widget.rs` and `widget.rs`.

- Changed the signature of `visible` method in `extend_widget.rs` and `widget.rs` to `fn visible(&self) -> bool`.

This commit refactors the `visible` method in `extend_widget.rs` and `widget.rs` to take `self` instead of `&mut self` as a parameter. This change allows the method to be used on immutable references, reducing potential side effects and improving code clarity.