### PR TITLE
feat: Register ReflectSizeUnifiedAdjust trait for SplitPane and exten…

### DIFF
--- a/macros/src/extend_container.rs
+++ b/macros/src/extend_container.rs
@@ -140,7 +140,10 @@ pub(crate) fn expand(
             };
 
             let reflect_split_infos_getter = if is_split_pane {
-                quote!(type_registry.register::<#name, ReflectSplitInfosGetter>();)
+                quote!(
+                    type_registry.register::<#name, ReflectSplitInfosGetter>();
+                    type_registry.register::<#name, ReflectSizeUnifiedAdjust>();
+                )
             } else {
                 proc_macro2::TokenStream::new()
             };

--- a/tmui/src/container.rs
+++ b/tmui/src/container.rs
@@ -139,3 +139,8 @@ impl WindowAcquire for dyn ContainerImpl {
         ApplicationWindow::window_of(self.window_id())
     }
 }
+
+#[reflect_trait]
+pub trait SizeUnifiedAdjust {
+    fn size_unified_adjust(&mut self);
+}

--- a/tmui/src/layout.rs
+++ b/tmui/src/layout.rs
@@ -1,5 +1,5 @@
 use crate::{
-    container::{Container, ContainerImpl, ScaleMeasure},
+    container::{Container, ContainerImpl, ReflectSizeUnifiedAdjust, ScaleMeasure},
     prelude::*,
     widget::{ScaleCalculate, WidgetImpl, WidgetSignals},
 };
@@ -117,7 +117,11 @@ impl SizeCalculation for dyn WidgetImpl {
         }
 
         if resized {
-            debug!("Widget {} resized in `pre_calc_size`, size: {:?}", self.name(), self.size());
+            debug!(
+                "Widget {} resized in `pre_calc_size`, size: {:?}",
+                self.name(),
+                self.size()
+            );
             emit!(self.size_changed(), self.size())
         }
         self.size()
@@ -137,7 +141,11 @@ impl SizeCalculation for dyn WidgetImpl {
         }
 
         if resized {
-            debug!("Widget {} resized in `calc_node_size`, size: {:?}", self.name(), self.size());
+            debug!(
+                "Widget {} resized in `calc_node_size`, size: {:?}",
+                self.name(),
+                self.size()
+            );
             emit!(self.size_changed(), self.size())
         }
     }
@@ -227,7 +235,11 @@ impl SizeCalculation for dyn WidgetImpl {
         }
 
         if resized {
-            debug!("Widget {} resized in `calc_leaf_size`, size: {:?}", self.name(), self.size());
+            debug!(
+                "Widget {} resized in `calc_leaf_size`, size: {:?}",
+                self.name(),
+                self.size()
+            );
             emit!(self.size_changed(), self.size())
         }
     }
@@ -310,6 +322,10 @@ impl LayoutManager {
                         });
                     }
                     Composition::FixedContainer => {
+                        let widget = ptr_mut!(widget_ptr);
+                        if let Some(unified) = cast_mut!(widget as SizeUnifiedAdjust) {
+                            unified.size_unified_adjust();
+                        }
                         children.unwrap().iter_mut().for_each(|child| {
                             Self::child_size_probe(window_size, size, *child);
                         });

--- a/tmui/src/prelude.rs
+++ b/tmui/src/prelude.rs
@@ -5,7 +5,7 @@ pub use tlib::signal;
 pub use crate::application_window::{current_window_id, ApplicationWindow};
 pub use crate::container::{
     Container, ContainerAcquire, ContainerImpl, ContainerImplExt, ContainerPointEffective,
-    ContainerScaleCalculate, ReflectContainerImpl, StaticContainerScaleCalculate,
+    ContainerScaleCalculate, ReflectContainerImpl, StaticContainerScaleCalculate, SizeUnifiedAdjust, ReflectSizeUnifiedAdjust
 };
 pub use crate::graphics::board::Board;
 pub use crate::graphics::drawing_context::DrawingContext;

--- a/tmui/src/split_pane.rs
+++ b/tmui/src/split_pane.rs
@@ -1,6 +1,9 @@
 use crate::{
     application_window::ApplicationWindow,
-    container::{ContainerScaleCalculate, StaticContainerScaleCalculate, SCALE_DISMISS},
+    container::{
+        ContainerScaleCalculate, ReflectSizeUnifiedAdjust, StaticContainerScaleCalculate,
+        SCALE_DISMISS,
+    },
     layout::LayoutManager,
     prelude::*,
     tlib::{
@@ -27,7 +30,8 @@ impl ObjectSubclass for SplitPane {
 
 impl ObjectImpl for SplitPane {
     fn type_register(&self, type_registry: &mut TypeRegistry) {
-        type_registry.register::<SplitPane, ReflectSplitInfosGetter>()
+        type_registry.register::<SplitPane, ReflectSplitInfosGetter>();
+        type_registry.register::<SplitPane, ReflectSizeUnifiedAdjust>();
     }
 }
 
@@ -115,7 +119,7 @@ impl ContainerLayout for SplitPane {
         let parent_rect = widget.contents_rect(None);
         let split_infos_getter = cast_mut!(widget as SplitInfosGetter).unwrap();
         for split_info in split_infos_getter.split_infos_vec() {
-            nonnull_mut!(split_info).calculate_layout(parent_rect)
+            nonnull_mut!(split_info).calculate_layout(parent_rect, true)
         }
         for split_info in split_infos_getter.split_infos_vec() {
             let split_info = nonnull_mut!(split_info);
@@ -208,7 +212,7 @@ impl SplitInfo {
         }
     }
 
-    pub(crate) fn calculate_layout(&mut self, parent_rect: Rect) {
+    pub fn calculate_layout(&mut self, parent_rect: Rect, calc_position: bool) {
         let widget = split_widget!(self);
         debug!(
             "Split-widget {} calcualte_layout, parent_rect {:?}",
@@ -220,8 +224,10 @@ impl SplitInfo {
             SplitType::SplitNone => {
                 widget.set_fixed_width(parent_rect.width());
                 widget.set_fixed_height(parent_rect.height());
-                widget.set_fixed_x(parent_rect.x());
-                widget.set_fixed_y(parent_rect.y());
+                if calc_position {
+                    widget.set_fixed_x(parent_rect.x());
+                    widget.set_fixed_y(parent_rect.y());
+                }
             }
 
             SplitType::SplitLeft => {
@@ -232,13 +238,17 @@ impl SplitInfo {
 
                 widget.set_fixed_width(new_width);
                 widget.set_fixed_height(from_rect.height());
-                widget.set_fixed_x(from_rect.x());
-                widget.set_fixed_y(from_rect.y());
+                if calc_position {
+                    widget.set_fixed_x(from_rect.x());
+                    widget.set_fixed_y(from_rect.y());
+                }
 
                 split_from_widget.set_fixed_width(new_width);
                 split_from_widget.set_fixed_height(from_rect.height());
-                split_from_widget.set_fixed_x(from_rect.x() + new_width);
-                split_from_widget.set_fixed_y(from_rect.y());
+                if calc_position {
+                    split_from_widget.set_fixed_x(from_rect.x() + new_width);
+                    split_from_widget.set_fixed_y(from_rect.y());
+                }
             }
 
             SplitType::SplitUp => {
@@ -249,13 +259,17 @@ impl SplitInfo {
 
                 widget.set_fixed_width(from_rect.width());
                 widget.set_fixed_height(new_height);
-                widget.set_fixed_x(from_rect.x());
-                widget.set_fixed_y(from_rect.y());
+                if calc_position {
+                    widget.set_fixed_x(from_rect.x());
+                    widget.set_fixed_y(from_rect.y());
+                }
 
                 split_from_widget.set_fixed_width(from_rect.width());
                 split_from_widget.set_fixed_height(new_height);
-                split_from_widget.set_fixed_x(from_rect.x());
-                split_from_widget.set_fixed_y(from_rect.y() + new_height);
+                if calc_position {
+                    split_from_widget.set_fixed_x(from_rect.x());
+                    split_from_widget.set_fixed_y(from_rect.y() + new_height);
+                }
             }
 
             SplitType::SplitRight => {
@@ -266,13 +280,17 @@ impl SplitInfo {
 
                 split_from_widget.set_fixed_width(new_width);
                 split_from_widget.set_fixed_height(from_rect.height());
-                split_from_widget.set_fixed_x(from_rect.x());
-                split_from_widget.set_fixed_y(from_rect.y());
+                if calc_position {
+                    split_from_widget.set_fixed_x(from_rect.x());
+                    split_from_widget.set_fixed_y(from_rect.y());
+                }
 
                 widget.set_fixed_width(new_width);
                 widget.set_fixed_height(from_rect.height());
-                widget.set_fixed_x(from_rect.x() + new_width);
-                widget.set_fixed_y(from_rect.y());
+                if calc_position {
+                    widget.set_fixed_x(from_rect.x() + new_width);
+                    widget.set_fixed_y(from_rect.y());
+                }
             }
 
             SplitType::SplitDown => {
@@ -283,13 +301,17 @@ impl SplitInfo {
 
                 split_from_widget.set_fixed_width(from_rect.width());
                 split_from_widget.set_fixed_height(new_height);
-                split_from_widget.set_fixed_x(from_rect.x());
-                split_from_widget.set_fixed_y(from_rect.y());
+                if calc_position {
+                    split_from_widget.set_fixed_x(from_rect.x());
+                    split_from_widget.set_fixed_y(from_rect.y());
+                }
 
                 widget.set_fixed_width(from_rect.width());
                 widget.set_fixed_height(new_height);
-                widget.set_fixed_x(from_rect.x());
-                widget.set_fixed_y(from_rect.y() + new_height);
+                if calc_position {
+                    widget.set_fixed_x(from_rect.x());
+                    widget.set_fixed_y(from_rect.y() + new_height);
+                }
             }
         }
     }


### PR DESCRIPTION
…d_container

This commit registers the `ReflectSizeUnifiedAdjust` trait for the `SplitPane` and `extend_container` modules. The `ReflectSizeUnifiedAdjust` trait provides a `size_unified_adjust` method that adjusts the size of widgets based on their parent container size. The `size_unified_adjust` method is implemented for `SplitPane`, which calculates the layout for split widgets and updates their sizes accordingly. Additionally, the `ReflectSizeUnifiedAdjust` trait is registered for the `SplitPane` and `extend_container` modules in the type registry.